### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm test
+      - name: Bump version
+        id: bump_version
+        uses: phips28/gh-action-bump-version@v11
+        with:
+          tag-prefix: v
+      - run: npm run build
+      - run: zip -r ../../chrome-extension-${{ steps.bump_version.outputs.newVersion }}.zip .
+        working-directory: dist/chrome-extension
+      - run: zip -r ../../firefox-extension-${{ steps.bump_version.outputs.newVersion }}.zip .
+        working-directory: dist/firefox-extension
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.bump_version.outputs.newTag }}
+          generate_release_notes: true
+          files: |
+            chrome-extension-${{ steps.bump_version.outputs.newVersion }}.zip
+            firefox-extension-${{ steps.bump_version.outputs.newVersion }}.zip

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Removes the stress of rolling dice in vtt foundry",
   "main": "index.js",
   "scripts": {
-    "build": "esbuild chrome-extension/background.ts --bundle --platform=browser --outfile=chrome-extension/background.js && esbuild firefox-extension/background.ts --bundle --platform=browser --outfile=firefox-extension/background.js",
+    "build": "rm -rf dist && mkdir -p dist/chrome-extension dist/firefox-extension && esbuild chrome-extension/background.ts --bundle --platform=browser --outdir=dist/chrome-extension && esbuild firefox-extension/background.ts --bundle --platform=browser --outdir=dist/firefox-extension && cp chrome-extension/manifest.json dist/chrome-extension/ && cp firefox-extension/manifest.json dist/firefox-extension/",
     "typecheck": "tsc --noEmit",
     "test": "npm run typecheck"
   },


### PR DESCRIPTION
## Summary
- add workflow to bump project version, build extension zips, and create a GitHub release with auto-generated notes
- direct extension builds to a dist folder so release zips contain only compiled assets

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1ed6794e4832cb8a8531bc83b55e2