### PR TITLE
Limit no-dice-no-cry naming to build artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ registers this handler with its browser's runtime API and bundles the result int
 1. Install dependencies: `npm install`
 2. Build the TypeScript background scripts: `npm run build`
 
-The generated `background.js` files are written to the extension folders and are ignored by git.
+The generated `background.js` files and updated manifests are written to `dist/no-dice-no-cry-{chrome,firefox}` and are ignored by git.

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "No Dice, No Cry!",
-  "version": "0.1.0",
+  "version": "1.0.1",
   "description": "Stub extension for Chrome.",
   "background": {
     "service_worker": "background.js"

--- a/firefox-extension/manifest.json
+++ b/firefox-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "No Dice, No Cry!",
-  "version": "0.1.0",
+  "version": "1.0.1",
   "description": "Stub extension for Firefox.",
   "background": {
     "scripts": ["background.js"]

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Removes the stress of rolling dice in vtt foundry",
   "main": "index.js",
   "scripts": {
-    "build": "rm -rf dist && mkdir -p dist/chrome-extension dist/firefox-extension && esbuild chrome-extension/background.ts --bundle --platform=browser --outdir=dist/chrome-extension && esbuild firefox-extension/background.ts --bundle --platform=browser --outdir=dist/firefox-extension && cp chrome-extension/manifest.json dist/chrome-extension/ && cp firefox-extension/manifest.json dist/firefox-extension/",
+    "build": "rm -rf dist && mkdir -p dist/no-dice-no-cry-chrome dist/no-dice-no-cry-firefox && esbuild chrome-extension/background.ts --bundle --platform=browser --outdir=dist/no-dice-no-cry-chrome && esbuild firefox-extension/background.ts --bundle --platform=browser --outdir=dist/no-dice-no-cry-firefox && node scripts/update-manifests.js",
     "typecheck": "tsc --noEmit",
     "test": "npm run typecheck"
   },

--- a/scripts/update-manifests.js
+++ b/scripts/update-manifests.js
@@ -1,0 +1,13 @@
+const fs = require('fs');
+const path = require('path');
+const root = __dirname ? path.resolve(__dirname, '..') : '..';
+const pkg = require(path.join(root, 'package.json'));
+
+for (const target of ['chrome', 'firefox']) {
+  const manifestPath = path.join(root, `${target}-extension`, 'manifest.json');
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  manifest.version = pkg.version;
+  const outDir = path.join(root, 'dist', `no-dice-no-cry-${target}`);
+  fs.mkdirSync(outDir, { recursive: true });
+  fs.writeFileSync(path.join(outDir, 'manifest.json'), JSON.stringify(manifest, null, 2));
+}


### PR DESCRIPTION
## Summary
- restore extension source folders to chrome-extension and firefox-extension
- build script outputs no-dice-no-cry-{chrome,firefox} with synced manifest versions
- update ignores, configs, and docs for new layout

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1f1f094a0832cb4f5db7589ef4f9d