### PR TITLE
feat: activate extension only on Foundry VTT pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ This repository now includes minimal stubs for the **No Dice, No Cry!** browser 
 - `firefox-extension/` – Manifest V2 stub for Mozilla Firefox.
 
 These stubs share a tiny TypeScript library that logs when **No Dice, No Cry!** installs. Each extension's background script
-registers this handler with its browser's runtime API and bundles the result into its own directory.
+registers this handler with its browser's runtime API and bundles the result into its own directory. Before installing, the
+script confirms the active tab is running Foundry VTT by checking for `window.game`.
 
 ### Building the extensions
 

--- a/chrome-extension/background.ts
+++ b/chrome-extension/background.ts
@@ -1,6 +1,11 @@
-import { handleInstall } from '../src/background';
+import { handleInstall, isFoundryVTT } from '../src/background';
 
 declare const chrome: any;
 
-chrome.runtime.onInstalled.addListener(handleInstall);
+chrome.tabs.onUpdated.addListener(async (tabId: number, changeInfo: any) => {
+  if (changeInfo.status === 'complete' && await isFoundryVTT(tabId)) {
+    handleInstall();
+  }
+});
+
 export {};

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -6,6 +6,8 @@
   "background": {
     "service_worker": "background.js"
   },
+  "permissions": ["scripting", "tabs"],
+  "host_permissions": ["<all_urls>"],
   "action": {
     "default_title": "No Dice, No Cry!"
   }

--- a/firefox-extension/background.ts
+++ b/firefox-extension/background.ts
@@ -1,6 +1,11 @@
-import { handleInstall } from '../src/background';
+import { handleInstall, isFoundryVTT } from '../src/background';
 
 declare const browser: any;
 
-browser.runtime.onInstalled.addListener(handleInstall);
+browser.tabs.onUpdated.addListener(async (tabId: number, changeInfo: any) => {
+  if (changeInfo.status === 'complete' && await isFoundryVTT(tabId)) {
+    handleInstall();
+  }
+});
+
 export {};

--- a/firefox-extension/manifest.json
+++ b/firefox-extension/manifest.json
@@ -5,5 +5,6 @@
   "description": "Stub extension for Firefox.",
   "background": {
     "scripts": ["background.js"]
-  }
+  },
+  "permissions": ["tabs", "<all_urls>"]
 }

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,3 +1,34 @@
+declare const chrome: any;
+declare const browser: any;
+
+function getRuntime(): any {
+  return typeof browser !== "undefined" ? browser : chrome;
+}
+
+export async function isFoundryVTT(tabId: number): Promise<boolean> {
+  const runtime = getRuntime();
+  if (!runtime) return false;
+
+  try {
+    if (runtime.scripting?.executeScript) {
+      const [result] = await runtime.scripting.executeScript({
+        target: { tabId },
+        func: () => Boolean((window as any).game),
+      });
+      return Boolean(result?.result);
+    } else if (runtime.tabs?.executeScript) {
+      const [result] = await runtime.tabs.executeScript(tabId, {
+        code: "Boolean(window.game)",
+      });
+      return Boolean(result);
+    }
+  } catch {
+    // ignored
+  }
+
+  return false;
+}
+
 export function handleInstall() {
   console.log("No Dice, No Cry! extension installed");
 }


### PR DESCRIPTION
## Summary
- detect Foundry VTT by checking for `window.game`
- only install extension when tabs are confirmed to be Foundry VTT
- request scripting and tab permissions for runtime checks
- document Foundry detection logic

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1f7fecbec832cb3931884433f47fa