### PR TITLE
guard background scripts when runtime unavailable

### DIFF
--- a/chrome-extension/background.ts
+++ b/chrome-extension/background.ts
@@ -1,16 +1,20 @@
-import { handleInstall, isFoundryVTT } from '../src/background';
+import { handleInstall, isFoundryVTT, getRuntime } from '../src/background';
 
-declare const chrome: any;
+const runtime = getRuntime();
 
-chrome.tabs.onUpdated.addListener(async (tabId: number, changeInfo: any) => {
-  console.log('Tab updated', tabId, changeInfo.status);
-  if (changeInfo.status === 'complete') {
-    const isFoundry = await isFoundryVTT(tabId);
-    console.log('isFoundryVTT', tabId, isFoundry);
-    if (isFoundry) {
-      await handleInstall(tabId);
+if (runtime?.tabs?.onUpdated?.addListener) {
+  runtime.tabs.onUpdated.addListener(async (tabId: number, changeInfo: any) => {
+    console.log('Tab updated', tabId, changeInfo.status);
+    if (changeInfo.status === 'complete') {
+      const isFoundry = await isFoundryVTT(tabId);
+      console.log('isFoundryVTT', tabId, isFoundry);
+      if (isFoundry) {
+        await handleInstall(tabId);
+      }
     }
-  }
-});
+  });
+} else {
+  console.warn('No runtime available for tabs.onUpdated');
+}
 
 export {};

--- a/firefox-extension/background.ts
+++ b/firefox-extension/background.ts
@@ -1,16 +1,20 @@
-import { handleInstall, isFoundryVTT } from '../src/background';
+import { handleInstall, isFoundryVTT, getRuntime } from '../src/background';
 
-declare const browser: any;
+const runtime = getRuntime();
 
-browser.tabs.onUpdated.addListener(async (tabId: number, changeInfo: any) => {
-  console.log('Tab updated', tabId, changeInfo.status);
-  if (changeInfo.status === 'complete') {
-    const isFoundry = await isFoundryVTT(tabId);
-    console.log('isFoundryVTT', tabId, isFoundry);
-    if (isFoundry) {
-      await handleInstall(tabId);
+if (runtime?.tabs?.onUpdated?.addListener) {
+  runtime.tabs.onUpdated.addListener(async (tabId: number, changeInfo: any) => {
+    console.log('Tab updated', tabId, changeInfo.status);
+    if (changeInfo.status === 'complete') {
+      const isFoundry = await isFoundryVTT(tabId);
+      console.log('isFoundryVTT', tabId, isFoundry);
+      if (isFoundry) {
+        await handleInstall(tabId);
+      }
     }
-  }
-});
+  });
+} else {
+  console.warn('No runtime available for tabs.onUpdated');
+}
 
 export {};

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,8 +1,14 @@
 declare const chrome: any;
 declare const browser: any;
 
-function getRuntime(): any {
-  return typeof browser !== "undefined" ? browser : chrome;
+export function getRuntime(): any {
+  if (typeof browser !== "undefined") {
+    return browser;
+  }
+  if (typeof chrome !== "undefined") {
+    return chrome;
+  }
+  return undefined;
 }
 
 export async function isFoundryVTT(tabId: number): Promise<boolean> {


### PR DESCRIPTION
## Summary
- export `getRuntime` to safely detect browser runtime
- wrap background listeners so they warn when no runtime exists

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b21749a7b8832c83b711c0c4fe3cf5