### PR TITLE
Use page context for detection and message injection

### DIFF
--- a/chrome-extension/background.ts
+++ b/chrome-extension/background.ts
@@ -3,16 +3,26 @@ import { handleInstall, isFoundryVTT, getRuntime } from '../src/background';
 const runtime = getRuntime();
 
 if (runtime?.tabs?.onUpdated?.addListener) {
-  runtime.tabs.onUpdated.addListener(async (tabId: number, changeInfo: any) => {
-    console.log('Tab updated', tabId, changeInfo.status);
-    if (changeInfo.status === 'complete') {
-      const isFoundry = await isFoundryVTT(tabId);
-      console.log('isFoundryVTT', tabId, isFoundry);
-      if (isFoundry) {
-        await handleInstall(tabId);
+  runtime.tabs.onUpdated.addListener(
+    async (tabId: number, changeInfo: any, tab: any) => {
+      const status = changeInfo.status ?? tab?.status;
+      if (status) {
+        console.log('Tab updated', tabId, status);
       }
-    }
-  });
+      if (changeInfo.status === 'complete') {
+        const isFoundry = await isFoundryVTT(tabId);
+        console.log('isFoundryVTT', tabId, isFoundry);
+        if (isFoundry) {
+          await handleInstall(tabId);
+        } else {
+          console.log(
+            'Skipping message injection; Foundry not detected on tab',
+            tabId,
+          );
+        }
+      }
+    },
+  );
 } else {
   console.warn('No runtime available for tabs.onUpdated');
 }

--- a/firefox-extension/background.ts
+++ b/firefox-extension/background.ts
@@ -3,16 +3,26 @@ import { handleInstall, isFoundryVTT, getRuntime } from '../src/background';
 const runtime = getRuntime();
 
 if (runtime?.tabs?.onUpdated?.addListener) {
-  runtime.tabs.onUpdated.addListener(async (tabId: number, changeInfo: any) => {
-    console.log('Tab updated', tabId, changeInfo.status);
-    if (changeInfo.status === 'complete') {
-      const isFoundry = await isFoundryVTT(tabId);
-      console.log('isFoundryVTT', tabId, isFoundry);
-      if (isFoundry) {
-        await handleInstall(tabId);
+  runtime.tabs.onUpdated.addListener(
+    async (tabId: number, changeInfo: any, tab: any) => {
+      const status = changeInfo.status ?? tab?.status;
+      if (status) {
+        console.log('Tab updated', tabId, status);
       }
-    }
-  });
+      if (changeInfo.status === 'complete') {
+        const isFoundry = await isFoundryVTT(tabId);
+        console.log('isFoundryVTT', tabId, isFoundry);
+        if (isFoundry) {
+          await handleInstall(tabId);
+        } else {
+          console.log(
+            'Skipping message injection; Foundry not detected on tab',
+            tabId,
+          );
+        }
+      }
+    },
+  );
 } else {
   console.warn('No runtime available for tabs.onUpdated');
 }

--- a/src/background.ts
+++ b/src/background.ts
@@ -23,6 +23,8 @@ export async function isFoundryVTT(tabId: number): Promise<boolean> {
       console.log("Checking for Foundry VTT via runtime.scripting on tab", tabId);
       const [result] = await runtime.scripting.executeScript({
         target: { tabId },
+        // Run in the page context so window.game is accessible
+        world: "MAIN",
         func: () => Boolean((window as any).game),
       });
       const isFoundry = Boolean(result?.result);
@@ -60,6 +62,8 @@ export async function handleInstall(tabId: number): Promise<void> {
       console.log("Injecting message via runtime.scripting to tab", tabId);
       await runtime.scripting.executeScript({
         target: { tabId },
+        // Execute in page context so ChatMessage is available
+        world: "MAIN",
         func: (msg: string) => {
           const send = () =>
             (window as any).ChatMessage?.create({ content: msg });


### PR DESCRIPTION
## Summary
- Run Foundry detection in the page's main world so `window.game` is accessible
- Inject welcome message from the main world so `ChatMessage` can post
- Log when message injection is skipped and avoid logging undefined tab statuses

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b21bfad5f8832c9f80c32ff38d7367