### PR TITLE
Prevent duplicate init messages

### DIFF
--- a/chrome-extension/background.ts
+++ b/chrome-extension/background.ts
@@ -1,6 +1,30 @@
-import { handleInstall, isFoundryVTT, getRuntime } from '../src/background';
+import {
+  handleInstall,
+  isFoundryVTT,
+  getRuntime,
+  resetInjected,
+} from '../src/background';
 
 const runtime = getRuntime();
+
+if (runtime?.webNavigation?.onBeforeNavigate?.addListener) {
+  runtime.webNavigation.onBeforeNavigate.addListener(
+    ({ tabId, frameId }: any) => {
+      if (frameId === 0) {
+        resetInjected(tabId);
+      }
+    },
+  );
+} else if (runtime?.tabs?.onUpdated?.addListener) {
+  // Fallback if webNavigation is unavailable
+  runtime.tabs.onUpdated.addListener((tabId: number, changeInfo: any) => {
+    if (changeInfo.status === 'loading') {
+      resetInjected(tabId);
+    }
+  });
+} else {
+  console.warn('No runtime available for navigation events');
+}
 
 if (runtime?.tabs?.onUpdated?.addListener) {
   runtime.tabs.onUpdated.addListener(

--- a/firefox-extension/background.ts
+++ b/firefox-extension/background.ts
@@ -1,6 +1,30 @@
-import { handleInstall, isFoundryVTT, getRuntime } from '../src/background';
+import {
+  handleInstall,
+  isFoundryVTT,
+  getRuntime,
+  resetInjected,
+} from '../src/background';
 
 const runtime = getRuntime();
+
+if (runtime?.webNavigation?.onBeforeNavigate?.addListener) {
+  runtime.webNavigation.onBeforeNavigate.addListener(
+    ({ tabId, frameId }: any) => {
+      if (frameId === 0) {
+        resetInjected(tabId);
+      }
+    },
+  );
+} else if (runtime?.tabs?.onUpdated?.addListener) {
+  // Fallback if webNavigation is unavailable
+  runtime.tabs.onUpdated.addListener((tabId: number, changeInfo: any) => {
+    if (changeInfo.status === 'loading') {
+      resetInjected(tabId);
+    }
+  });
+} else {
+  console.warn('No runtime available for navigation events');
+}
 
 if (runtime?.tabs?.onUpdated?.addListener) {
   runtime.tabs.onUpdated.addListener(

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,6 +1,12 @@
 declare const chrome: any;
 declare const browser: any;
 
+const injectedTabs = new Set<number>();
+
+export function resetInjected(tabId: number): void {
+  injectedTabs.delete(tabId);
+}
+
 export function getRuntime(): any {
   if (typeof browser !== "undefined") {
     return browser;
@@ -48,6 +54,11 @@ export async function isFoundryVTT(tabId: number): Promise<boolean> {
 }
 
 export async function handleInstall(tabId: number): Promise<void> {
+  if (injectedTabs.has(tabId)) {
+    console.log("Message already injected for tab", tabId);
+    return;
+  }
+  injectedTabs.add(tabId);
   const runtime = getRuntime();
   if (!runtime) {
     console.log("No runtime available for handleInstall on tab", tabId);


### PR DESCRIPTION
## Summary
- Reset injection tracking on top-level navigation to avoid duplicate init messages
- Fallback to tabs API when webNavigation is unavailable

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b22a2ca2f4832ca22cce53b3e350f5