### PR TITLE
fix: use Map.set instead of add

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -68,7 +68,8 @@ export async function handleInstall(tabId: number): Promise<void> {
     console.log("Message already injected for tab", tabId);
     return;
   }
-  injectedTabs.add(tabId);
+  // Mark this tab as processed to prevent duplicate injections
+  injectedTabs.set(tabId, undefined);
   const runtime = getRuntime();
   if (!runtime) {
     console.log("No runtime available for handleInstall on tab", tabId);


### PR DESCRIPTION
## Summary
- fix handleInstall to use Map.set instead of invalid Map.add

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b320a5a050832c9c08c2ecac8e43da