### PR TITLE
Prevent duplicate message injection on undefined loading events

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -12,7 +12,11 @@ export function resetInjected(
   if (prev === undefined) {
     return;
   }
-  if (transitionType === "reload" || prev !== url) {
+  if (transitionType === "reload") {
+    injectedTabs.delete(tabId);
+    return;
+  }
+  if (url !== undefined && prev !== url) {
     injectedTabs.delete(tabId);
   }
 }


### PR DESCRIPTION
## Summary
- avoid clearing injected tab records when `tabs.onUpdated` fires with undefined URL

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b325aacf8c832c9463b73569f4be7e