### PR TITLE
Toggle extension activation via icon click

### DIFF
--- a/chrome-extension/background.ts
+++ b/chrome-extension/background.ts
@@ -3,6 +3,7 @@ import {
   isFoundryVTT,
   getRuntime,
   resetInjected,
+  toggleActive,
 } from '../src/background';
 
 const runtime = getRuntime();
@@ -49,6 +50,42 @@ if (runtime?.tabs?.onUpdated?.addListener) {
   );
 } else {
   console.warn('No runtime available for tabs.onUpdated');
+}
+
+if (runtime?.action?.onClicked?.addListener) {
+  runtime.action.onClicked.addListener(async (tab: any) => {
+    const tabId = tab?.id;
+    if (typeof tabId === 'number') {
+      const isFoundry = await isFoundryVTT(tabId);
+      console.log('Toggle requested on tab', tabId, isFoundry);
+      if (isFoundry) {
+        await toggleActive(tabId);
+      } else {
+        console.log(
+          'Skipping toggle; Foundry not detected on tab',
+          tabId,
+        );
+      }
+    }
+  });
+} else if (runtime?.browserAction?.onClicked?.addListener) {
+  runtime.browserAction.onClicked.addListener(async (tab: any) => {
+    const tabId = tab?.id;
+    if (typeof tabId === 'number') {
+      const isFoundry = await isFoundryVTT(tabId);
+      console.log('Toggle requested on tab', tabId, isFoundry);
+      if (isFoundry) {
+        await toggleActive(tabId);
+      } else {
+        console.log(
+          'Skipping toggle; Foundry not detected on tab',
+          tabId,
+        );
+      }
+    }
+  });
+} else {
+  console.warn('No runtime available for action clicks');
 }
 
 export {};

--- a/firefox-extension/background.ts
+++ b/firefox-extension/background.ts
@@ -3,6 +3,7 @@ import {
   isFoundryVTT,
   getRuntime,
   resetInjected,
+  toggleActive,
 } from '../src/background';
 
 const runtime = getRuntime();
@@ -49,6 +50,42 @@ if (runtime?.tabs?.onUpdated?.addListener) {
   );
 } else {
   console.warn('No runtime available for tabs.onUpdated');
+}
+
+if (runtime?.action?.onClicked?.addListener) {
+  runtime.action.onClicked.addListener(async (tab: any) => {
+    const tabId = tab?.id;
+    if (typeof tabId === 'number') {
+      const isFoundry = await isFoundryVTT(tabId);
+      console.log('Toggle requested on tab', tabId, isFoundry);
+      if (isFoundry) {
+        await toggleActive(tabId);
+      } else {
+        console.log(
+          'Skipping toggle; Foundry not detected on tab',
+          tabId,
+        );
+      }
+    }
+  });
+} else if (runtime?.browserAction?.onClicked?.addListener) {
+  runtime.browserAction.onClicked.addListener(async (tab: any) => {
+    const tabId = tab?.id;
+    if (typeof tabId === 'number') {
+      const isFoundry = await isFoundryVTT(tabId);
+      console.log('Toggle requested on tab', tabId, isFoundry);
+      if (isFoundry) {
+        await toggleActive(tabId);
+      } else {
+        console.log(
+          'Skipping toggle; Foundry not detected on tab',
+          tabId,
+        );
+      }
+    }
+  });
+} else {
+  console.warn('No runtime available for action clicks');
 }
 
 export {};

--- a/firefox-extension/manifest.json
+++ b/firefox-extension/manifest.json
@@ -6,5 +6,8 @@
   "background": {
     "scripts": ["background.js"]
   },
+  "browser_action": {
+    "default_title": "No Dice, No Cry!"
+  },
   "permissions": ["tabs", "<all_urls>"]
 }

--- a/src/background.ts
+++ b/src/background.ts
@@ -2,6 +2,7 @@ declare const chrome: any;
 declare const browser: any;
 
 const injectedTabs = new Map<number, string | undefined>();
+const activeTabs = new Set<number>();
 
 export function resetInjected(
   tabId: number,
@@ -67,6 +68,55 @@ export async function isFoundryVTT(tabId: number): Promise<boolean> {
   return false;
 }
 
+export async function sendChatMessage(
+  tabId: number,
+  message: string,
+): Promise<void> {
+  const runtime = getRuntime();
+  if (!runtime) {
+    console.log("No runtime available for sendChatMessage on tab", tabId);
+    return;
+  }
+  try {
+    if (runtime.scripting?.executeScript) {
+      console.log("Injecting message via runtime.scripting to tab", tabId);
+      await runtime.scripting.executeScript({
+        target: { tabId },
+        world: "MAIN",
+        func: (msg: string) => {
+          const send = () => {
+            const author = (window as any).game?.user?.id;
+            const ChatMessage = (window as any).ChatMessage;
+            if (!author || !ChatMessage) {
+              console.warn(
+                "Cannot inject message: missing author or ChatMessage",
+              );
+              return;
+            }
+            ChatMessage.create({ content: msg, author });
+          };
+          if ((window as any).game?.ready) {
+            send();
+          } else {
+            (window as any).Hooks?.once?.("ready", send);
+          }
+        },
+        args: [message],
+      });
+    } else if (runtime.tabs?.executeScript) {
+      console.log("Injecting message via runtime.tabs to tab", tabId);
+      await runtime.tabs.executeScript(tabId, {
+        code: `(function(){const send=()=>{const a=window.game?.user?.id;const CM=window.ChatMessage;if(!a||!CM){console.warn("Cannot inject message: missing author or ChatMessage");return;}CM.create({content: ${JSON.stringify(
+          message,
+        )},author:a});};if(window.game?.ready){send();}else{window.Hooks?.once("ready",send);}})();`,
+      });
+    }
+    console.log("Chat message injection attempted for tab", tabId);
+  } catch (err) {
+    console.warn("sendChatMessage failed for tab", tabId, err);
+  }
+}
+
 export async function handleInstall(tabId: number): Promise<void> {
   if (injectedTabs.has(tabId)) {
     console.log("Message already injected for tab", tabId);
@@ -96,43 +146,20 @@ export async function handleInstall(tabId: number): Promise<void> {
   const message =
     "Rolling dice with unknown results gives me a lot of stress, so I'm using <a href='https://github.com/foundry-no-dice-no-cry'>no-dice-no-cry</a> to reduce it.";
 
-  try {
-    if (runtime.scripting?.executeScript) {
-        console.log("Injecting message via runtime.scripting to tab", tabId);
-        await runtime.scripting.executeScript({
-          target: { tabId },
-          // Execute in page context so ChatMessage is available
-          world: "MAIN",
-          func: (msg: string) => {
-            const send = () => {
-              const author = (window as any).game?.user?.id;
-              const ChatMessage = (window as any).ChatMessage;
-              if (!author || !ChatMessage) {
-                console.warn("Cannot inject message: missing author or ChatMessage");
-                return;
-              }
-              ChatMessage.create({ content: msg, author });
-            };
-            if ((window as any).game?.ready) {
-              send();
-            } else {
-              (window as any).Hooks?.once?.("ready", send);
-            }
-          },
-          args: [message],
-        });
-    } else if (runtime.tabs?.executeScript) {
-        console.log("Injecting message via runtime.tabs to tab", tabId);
-        await runtime.tabs.executeScript(tabId, {
-          code: `(function(){const send=()=>{const a=window.game?.user?.id;const CM=window.ChatMessage;if(!a||!CM){console.warn("Cannot inject message: missing author or ChatMessage");return;}CM.create({content: ${JSON.stringify(
-            message,
-          )},author:a});};if(window.game?.ready){send();}else{window.Hooks?.once?("ready",send);}})();`,
-        });
-      }
-    console.log("Message injection attempted for tab", tabId);
-  } catch (err) {
-    console.warn("handleInstall failed for tab", tabId, err);
-  }
-
+  await sendChatMessage(tabId, message);
   console.log("No Dice, No Cry! extension installed");
+}
+
+export async function toggleActive(tabId: number): Promise<void> {
+  const isActive = activeTabs.has(tabId);
+  if (isActive) {
+    activeTabs.delete(tabId);
+  } else {
+    activeTabs.add(tabId);
+  }
+  const msg = isActive
+    ? "No Dice, No Cry! deactivated"
+    : "No Dice, No Cry! activated";
+  await sendChatMessage(tabId, msg);
+  console.log("Toggled active state for tab", tabId, !isActive);
 }


### PR DESCRIPTION
## Summary
- add shared chat message utility and activation state tracking
- allow toggling extension via toolbar icon and announce in Foundry chat
- expose toolbar icon for Firefox

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b327db0a64832c83745be51ab94197