### PR TITLE
Use icon.pgn for extension icons

### DIFF
--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -9,6 +9,12 @@
   "permissions": ["scripting", "tabs"],
   "host_permissions": ["<all_urls>"],
   "action": {
-    "default_title": "No Dice, No Cry!"
+    "default_title": "No Dice, No Cry!",
+    "default_icon": "icon.pgn"
+  },
+  "icons": {
+    "16": "icon.pgn",
+    "48": "icon.pgn",
+    "128": "icon.pgn"
   }
 }

--- a/firefox-extension/manifest.json
+++ b/firefox-extension/manifest.json
@@ -6,5 +6,14 @@
   "background": {
     "scripts": ["background.js"]
   },
-  "permissions": ["tabs", "<all_urls>"]
+  "permissions": ["tabs", "<all_urls>"],
+  "browser_action": {
+    "default_title": "No Dice, No Cry!",
+    "default_icon": "icon.pgn"
+  },
+  "icons": {
+    "16": "icon.pgn",
+    "48": "icon.pgn",
+    "128": "icon.pgn"
+  }
 }

--- a/scripts/update-manifests.js
+++ b/scripts/update-manifests.js
@@ -10,4 +10,5 @@ for (const target of ['chrome', 'firefox']) {
   const outDir = path.join(root, 'dist', `no-dice-no-cry-${target}`);
   fs.mkdirSync(outDir, { recursive: true });
   fs.writeFileSync(path.join(outDir, 'manifest.json'), JSON.stringify(manifest, null, 2));
+  fs.copyFileSync(path.join(root, 'icon.png'), path.join(outDir, 'icon.pgn'));
 }


### PR DESCRIPTION
## Summary
- reference icon.pgn in Chrome and Firefox extension manifests
- copy icon into each dist folder during build instead of storing it in source directories

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b32ba702d4832c8f2dbc34089a9f5c