### PR TITLE
Fix extension icon mime type

### DIFF
--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -10,11 +10,11 @@
   "host_permissions": ["<all_urls>"],
   "action": {
     "default_title": "No Dice, No Cry!",
-    "default_icon": "icon.pgn"
+    "default_icon": "icon.png"
   },
   "icons": {
-    "16": "icon.pgn",
-    "48": "icon.pgn",
-    "128": "icon.pgn"
+    "16": "icon.png",
+    "48": "icon.png",
+    "128": "icon.png"
   }
 }

--- a/firefox-extension/manifest.json
+++ b/firefox-extension/manifest.json
@@ -9,11 +9,11 @@
   "permissions": ["tabs", "<all_urls>"],
   "browser_action": {
     "default_title": "No Dice, No Cry!",
-    "default_icon": "icon.pgn"
+    "default_icon": "icon.png"
   },
   "icons": {
-    "16": "icon.pgn",
-    "48": "icon.pgn",
-    "128": "icon.pgn"
+    "16": "icon.png",
+    "48": "icon.png",
+    "128": "icon.png"
   }
 }

--- a/scripts/update-manifests.js
+++ b/scripts/update-manifests.js
@@ -10,5 +10,5 @@ for (const target of ['chrome', 'firefox']) {
   const outDir = path.join(root, 'dist', `no-dice-no-cry-${target}`);
   fs.mkdirSync(outDir, { recursive: true });
   fs.writeFileSync(path.join(outDir, 'manifest.json'), JSON.stringify(manifest, null, 2));
-  fs.copyFileSync(path.join(root, 'icon.png'), path.join(outDir, 'icon.pgn'));
+  fs.copyFileSync(path.join(root, 'icon.png'), path.join(outDir, 'icon.png'));
 }


### PR DESCRIPTION
## Summary
- use correct PNG icon in browser manifests
- copy icon.png during manifest build

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6e4a2fe04832c887cde4bc14dc514