### PR TITLE
feat: start disabled and toggle extension icon

### DIFF
--- a/chrome-extension/background.ts
+++ b/chrome-extension/background.ts
@@ -4,6 +4,7 @@ import {
   getRuntime,
   resetInjected,
   toggleActive,
+  isActive,
 } from '../src/background';
 
 const runtime = getRuntime();
@@ -38,7 +39,14 @@ if (runtime?.tabs?.onUpdated?.addListener) {
         const isFoundry = await isFoundryVTT(tabId);
         console.log('isFoundryVTT', tabId, isFoundry);
         if (isFoundry) {
-          await handleInstall(tabId);
+          if (isActive(tabId)) {
+            await handleInstall(tabId);
+          } else {
+            console.log(
+              'Skipping message injection; extension disabled on tab',
+              tabId,
+            );
+          }
         } else {
           console.log(
             'Skipping message injection; Foundry not detected on tab',

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -10,7 +10,7 @@
   "host_permissions": ["<all_urls>"],
   "action": {
     "default_title": "No Dice, No Cry!",
-    "default_icon": "icon.png"
+    "default_icon": "icon_disabled.png"
   },
   "icons": {
     "16": "icon.png",

--- a/firefox-extension/background.ts
+++ b/firefox-extension/background.ts
@@ -4,6 +4,7 @@ import {
   getRuntime,
   resetInjected,
   toggleActive,
+  isActive,
 } from '../src/background';
 
 const runtime = getRuntime();
@@ -38,7 +39,14 @@ if (runtime?.tabs?.onUpdated?.addListener) {
         const isFoundry = await isFoundryVTT(tabId);
         console.log('isFoundryVTT', tabId, isFoundry);
         if (isFoundry) {
-          await handleInstall(tabId);
+          if (isActive(tabId)) {
+            await handleInstall(tabId);
+          } else {
+            console.log(
+              'Skipping message injection; extension disabled on tab',
+              tabId,
+            );
+          }
         } else {
           console.log(
             'Skipping message injection; Foundry not detected on tab',

--- a/firefox-extension/manifest.json
+++ b/firefox-extension/manifest.json
@@ -9,7 +9,7 @@
   "permissions": ["tabs", "<all_urls>"],
   "browser_action": {
     "default_title": "No Dice, No Cry!",
-    "default_icon": "icon.png"
+    "default_icon": "icon_disabled.png"
   },
   "icons": {
     "16": "icon.png",

--- a/scripts/update-manifests.js
+++ b/scripts/update-manifests.js
@@ -11,4 +11,8 @@ for (const target of ['chrome', 'firefox']) {
   fs.mkdirSync(outDir, { recursive: true });
   fs.writeFileSync(path.join(outDir, 'manifest.json'), JSON.stringify(manifest, null, 2));
   fs.copyFileSync(path.join(root, 'icon.png'), path.join(outDir, 'icon.png'));
+  fs.copyFileSync(
+    path.join(root, 'icon_disabled.png'),
+    path.join(outDir, 'icon_disabled.png'),
+  );
 }


### PR DESCRIPTION
## Summary
- show `icon_disabled.png` by default in both browser manifests
- toggle action icon and send message when enabling/disabling extension
- include `icon_disabled.png` in build outputs

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6f0c615c8832c842895559ecc70ca