### PR TITLE
Ensure 3D dice results are zeroed out

### DIFF
--- a/src/replaceDiceWithZero.ts
+++ b/src/replaceDiceWithZero.ts
@@ -5,12 +5,36 @@ export function replaceDiceWithZero(): void {
       return;
     }
     const proto = Roll.prototype as any;
+
+    // Patch individual die rolls so hooks like Dice So Nice receive zeroed results
+    const diceTypes = (window as any).CONFIG?.Dice?.types;
+    Object.values(diceTypes || {}).forEach((Die: any) => {
+      const dProto = Die?.prototype;
+      if (!dProto || dProto._noDiceNoCryPatched) {
+        return;
+      }
+      dProto._noDiceNoCryOriginalRoll = dProto.roll;
+      dProto.roll = function (...rollArgs: any[]): any {
+        const roll = dProto._noDiceNoCryOriginalRoll.apply(this, rollArgs);
+        if (roll && typeof roll.result === "number") {
+          roll.result = 0;
+        }
+        return roll;
+      };
+      dProto._noDiceNoCryPatched = true;
+    });
+
     proto._noDiceNoCryOriginalEvaluate = proto._evaluate;
     proto._evaluate = async function (...args: any[]): Promise<any> {
       await proto._noDiceNoCryOriginalEvaluate.apply(this, args);
       this.terms?.forEach((t: any) => {
         if (Array.isArray(t.results)) {
-          t.results.forEach((r: any) => (r.result = 0));
+          t.results.forEach((r: any) => {
+            r.result = 0;
+          });
+          if (typeof t.total === "number") {
+            t.total = 0;
+          }
         }
       });
       this._total = 0;
@@ -30,6 +54,21 @@ export function replaceDiceWithZero(): void {
 export function restoreDice(): void {
   const Roll = (window as any).Roll;
   const proto = Roll?.prototype as any;
+  const diceTypes = (window as any).CONFIG?.Dice?.types;
+  if (diceTypes) {
+    Object.values(diceTypes).forEach((Die: any) => {
+      const dProto = Die?.prototype;
+      if (!dProto?._noDiceNoCryPatched) {
+        return;
+      }
+      if (dProto._noDiceNoCryOriginalRoll) {
+        dProto.roll = dProto._noDiceNoCryOriginalRoll;
+        delete dProto._noDiceNoCryOriginalRoll;
+      }
+      delete dProto._noDiceNoCryPatched;
+    });
+  }
+
   if (!Roll || !proto?._noDiceNoCryPatched) {
     return;
   }


### PR DESCRIPTION
## Summary
- Patch die `roll` method across all dice types so hooks like Dice So Nice see 0 for each roll
- Keep roll evaluation override to zero term totals and final results
- Provide restore logic for die roll patches

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b70d59f318832c876ebc1290bbae6e